### PR TITLE
MH-12607 Patch: calculate the process-smil job load based on the encoding profiles used.

### DIFF
--- a/etc/org.opencastproject.composer.impl.ComposerServiceImpl.cfg
+++ b/etc/org.opencastproject.composer.impl.ComposerServiceImpl.cfg
@@ -1,11 +1,15 @@
-# process-smiltrack operation stitches all the editor segments and transcode with multiple
-# encoding profiles concurrently, the jobload is
-# job.load.process_smil + number_of_encoding_profiles * job.load.process_smil.per_encoding_profile
-# and maxes out at job.load.process_smil.max
+# Job load for process-smiltrack and multiencode is calculated based on the encoding profiles used. 
+# Their job loads are summed up and multiplied by a factor.
+# The factor represents the adjustment that should be made assuming each profile job load was specified
+# based on it running with one input -> one output so normally will be a number 0 < n <= 1.
+# Their job loads maxes out at job.load.max.multiple.profiles.
+# Default: 0.8
+#job.load.max.multiple.profiles=0.8
 
-job.load.process_smil = 1
-job.load.process_smil.per_encoding_profile = .5
-job.load.process_smil.max = 4
+# The process-smiltrack operation stitches all the editor segments and transcode with multiple
+# encoding profiles concurrently.
+# Default: 0.5
+#job.load.factor.process.smil=0.5
 
 # Transition duration in seconds between each edited section when using process-smiltrack operation
 # If it is set to 0, there is no transition between each segment


### PR DESCRIPTION
Job load for process-smiltrack is calculated based on the encoding profiles used. The encoding profile job loads are added and multiplied by a configurable factor. The factor represents the adjustment that should be made assuming each profile job load was defined based on it running with one input -> one output so normally will be a number 0 < n <= 1. The maximum load can be configured in job.load.max.multiple.profiles.